### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: Build Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 5.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore


### PR DESCRIPTION
没什么用的 CI
作用是可以看到每一个提交和 PR 的代码是否能编译通过 同时可以看到 MSBuild 输出的错误和警告
在处理 PR 的时候还是比较方便的